### PR TITLE
Fix code scanning alert no. 3: Default version of SSL/TLS may be insecure

### DIFF
--- a/docker/ciscoasa/dist/asa_server.py
+++ b/docker/ciscoasa/dist/asa_server.py
@@ -290,7 +290,10 @@ if __name__ == '__main__':
             if not cert:
                 import gencert
                 cert = gencert.gencert()
-            httpd.socket = ssl.wrap_socket(httpd.socket, certfile=cert, server_side=True)
+            context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            context.load_cert_chain(certfile=cert)
+            httpd.socket = context.wrap_socket(httpd.socket, server_side=True)
 
         logger.info('Starting server on port {:d}/tcp, use <Ctrl-C> to stop'.format(port))
         hpfl.log('info', 'Starting server on port {:d}/tcp, use <Ctrl-C> to stop'.format(port))


### PR DESCRIPTION
### **User description**
Fixes [https://github.com/khulnasoft/cyberpot/security/code-scanning/3](https://github.com/khulnasoft/cyberpot/security/code-scanning/3)

To fix the problem, we should replace the deprecated `ssl.wrap_socket` method with a more secure and modern approach. The recommended way is to use `ssl.SSLContext` or `ssl.create_default_context` to ensure that a secure protocol like TLS 1.2 or above is used.

1. Create an `SSLContext` object and set its `minimum_version` to `ssl.TLSVersion.TLSv1_2`.
2. Wrap the server socket using this context instead of `ssl.wrap_socket`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace deprecated ssl.wrap_socket method with ssl.SSLContext to address security alert regarding insecure default SSL/TLS version.


___

### **PR Type**
Bug fix


___

### **Description**
- Replaced the deprecated `ssl.wrap_socket` method with `ssl.create_default_context` to address security concerns.
- Ensured the use of TLS 1.2 or above by setting `minimum_version` in the SSL context.
- Loaded the certificate chain using `context.load_cert_chain` for secure server-side communication.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>asa_server.py</strong><dd><code>Replace deprecated SSL method with secure context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker/ciscoasa/dist/asa_server.py

<li>Replaced <code>ssl.wrap_socket</code> with <code>ssl.create_default_context</code>.<br> <li> Set <code>minimum_version</code> to <code>ssl.TLSVersion.TLSv1_2</code> for security.<br> <li> Loaded certificate chain using <code>context.load_cert_chain</code>.<br> <li> Wrapped server socket with the secure context.<br>


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/cyberpot/pull/11/files#diff-ae5a5bae2f33ce3543cf595312c1bdf0ab46ebd2d95478e9919fea076a1f8225">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information