### PR TITLE
Bump Elastic Stack to 8.17.3

### DIFF
--- a/docker/elk/elasticsearch/Dockerfile
+++ b/docker/elk/elasticsearch/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 #
 # VARS
-ENV ES_VER=8.14.2
+ENV ES_VER=8.17.3
 #
 # Include dist
 COPY dist/ /root/dist/

--- a/docker/elk/kibana/Dockerfile
+++ b/docker/elk/kibana/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 #
 # VARS
-ENV KB_VER=8.14.2
+ENV KB_VER=8.14.3
 # Include dist
 COPY dist/ /root/dist/
 #

--- a/docker/elk/logstash/Dockerfile
+++ b/docker/elk/logstash/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:22.04
 #
 # VARS
-ENV LS_VER=8.14.2
+ENV LS_VER=8.17.3
 # Include dist
 COPY dist/ /root/dist/
 #


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #




**[Signed commits](../blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [*] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->

## Summary by Sourcery

Build:
- Update the Elasticsearch Dockerfile to use version 8.17.3 of the Elastic Stack.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Elasticsearch to version 8.17.3.
	- Updated Kibana to version 8.14.3.
	- Updated Logstash to version 8.17.3.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->